### PR TITLE
Fix error when using ROOT

### DIFF
--- a/build-docbook-catalog
+++ b/build-docbook-catalog
@@ -137,8 +137,10 @@ set_dtds() {
 	local d=${ROOT}${DOCBOOKDIR}
 	if [[ -d ${d} ]] ; then
 		pushd "${d}" >/dev/null || return 1
-		mapfile -d $'\0' DTDS < <(find xml-dtd-*/ -name docbookx.dtd -print0)
-		mapfile -d $'\0' SIMPLE_DTDS < <(find xml-simple-dtd-*/ -name sdocbook.dtd -print0)
+		shopt -s nullglob
+		DTDS=( xml-dtd-*/docbookx.dtd )
+		SIMPLE_DTDS=( xml-simple-dtd-*/sdocbook.dtd )
+		shopt -u nullglob
 		popd >/dev/null || return 1
 	fi
 

--- a/build-docbook-catalog
+++ b/build-docbook-catalog
@@ -187,7 +187,7 @@ create_catalogs() {
 		verb "Found XML Catalog root ${ROOTCATALOG}"
 		# clean out existing entries
 		verb "  Cleaning existing ${CATALOG} delegates from ${ROOTCATALOG}"
-		cp "${ROOTCATALOG}" "${ROOTCATALOG}.tmp"
+		cp "${ROOT}${ROOTCATALOG}" "${ROOT}${ROOTCATALOG}.tmp"
 		clean_catalog "file://${CATALOG}" "${ROOTCATALOG}.tmp"
 	fi
 


### PR DESCRIPTION
When clearing the root catalog, we were not taking the ROOT variable into account.

The find command was also failing if one of the directories didn't exist. By using `-path` we can avoid using bash globs.